### PR TITLE
fixs: bug fix generated code is not compiled

### DIFF
--- a/internal/generator.go
+++ b/internal/generator.go
@@ -89,10 +89,10 @@ func (g *Generator) appendMethod(funcs []FuncType, _ string) {
 
 		g.Printf("if i, ok := d.store[\"%s\"]; ok {\n", f.Name)
 		g.Printf("instance, ok := i.(%s)\n", returnType.ConvertName(g.PackageName))
-		g.Printf("if ok {\n")
-		g.Printf("return instance, nil\n")
-		g.Printf("}\n")
+		g.Printf("if !ok {\n")
 		g.Printf("return nil, fmt.Errorf(\"invalid instance is cached %%v\", instance)\n")
+		g.Printf("}\n")
+		g.Printf("return instance, nil\n")
 		g.Printf("}\n")
 
 		dep := make([]string, 0, len(f.ArgumentTypes))

--- a/internal/generator.go
+++ b/internal/generator.go
@@ -88,9 +88,9 @@ func (g *Generator) appendMethod(funcs []FuncType, _ string) {
 		g.Printf("(%s, error) {\n", returnType.ConvertName(g.PackageName))
 
 		g.Printf("if i, ok := d.store[\"%s\"]; ok {\n", f.Name)
-		g.Printf("if instance, ok := i.(%s); ok {\n", returnType.ConvertName(g.PackageName))
+		g.Printf("instance, ok := i.(%s)\n", returnType.ConvertName(g.PackageName))
+		g.Printf("if ok {\n")
 		g.Printf("return instance, nil\n")
-
 		g.Printf("}\n")
 		g.Printf("return nil, fmt.Errorf(\"invalid instance is cached %%v\", instance)\n")
 		g.Printf("}\n")

--- a/internal/generator_test.go
+++ b/internal/generator_test.go
@@ -59,10 +59,11 @@ func TestGenerator_appendStructDef(t *testing.T) {
 func TestGenerator_appendMethods(t *testing.T) {
 	ex := pretty(t, []byte(`func (d *dicontainer) SampleComponent() (SampleComponent, error) {
 	if i, ok := d.store["SampleComponent"]; ok {
-		if instance, ok := i.(SampleComponent); ok {
-			return instance, nil
+		instance, ok := i.(SampleComponent)
+		if !ok {
+			return nil, fmt.Errorf("invalid instance is cached %v", instance)
 		}
-		return nil, fmt.Errorf("invalid instance is cached %v", instance)
+		return instance, nil
 	}
 	dep0, err := d.Dependency()
 	if err != nil {
@@ -109,10 +110,11 @@ func TestGenerator_appendMethods(t *testing.T) {
 func TestGenerator_appendMethodsMultipleDependencies(t *testing.T) {
 	ex := pretty(t, []byte(`func (d *dicontainer) SampleComponent() (SampleComponent, error) {
 	if i, ok := d.store["SampleComponent"]; ok {
-		if instance, ok := i.(SampleComponent); ok {
-			return instance, nil
+		instance, ok := i.(SampleComponent)
+		if !ok {
+			return nil, fmt.Errorf("invalid instance is cached %v", instance)
 		}
-		return nil, fmt.Errorf("invalid instance is cached %v", instance)
+		return instance, nil
 	}
 	dep0, err := d.Dependency1()
 	if err != nil {
@@ -185,10 +187,11 @@ func TestGenerate(t *testing.T) {
 
 	func (d *dicontainer) SampleComponent() (SampleComponent, error) {
 		if i, ok := d.store["SampleComponent"]; ok {
-			if instance, ok := i.(SampleComponent); ok {
-				return instance, nil
+			instance, ok := i.(SampleComponent)
+			if !ok {
+				return nil, fmt.Errorf("invalid instance is cached %v", instance)
 			}
-			return nil, fmt.Errorf("invalid instance is cached %v", instance)
+			return instance, nil
 		}
 		dep0, err := d.Dependency1()
 		if err != nil {
@@ -270,10 +273,11 @@ func TestGenerateSubPackage(t *testing.T) {
 
 	func (d *dicontainer) SampleComponent() (sample.SampleComponent, error) {
 		if i, ok := d.store["SampleComponent"]; ok {
-			if instance, ok := i.(sample.SampleComponent); ok {
-				return instance, nil
+			instance, ok := i.(sample.SampleComponent)
+			if !ok {
+				return nil, fmt.Errorf("invalid instance is cached %v", instance)
 			}
-			return nil, fmt.Errorf("invalid instance is cached %v", instance)
+			return instance, nil
 		}
 		dep0, err := d.Dependency1()
 		if err != nil {

--- a/main.go
+++ b/main.go
@@ -97,6 +97,7 @@ func runGenerate(pkgs []string, filename string, dry bool) error {
 	g := internal.NewGenerator()
 
 	if err := g.Generate(it, funcs); err != nil {
+		fmt.Println("debug")
 		return err
 	}
 

--- a/main.go
+++ b/main.go
@@ -97,7 +97,6 @@ func runGenerate(pkgs []string, filename string, dry bool) error {
 	g := internal.NewGenerator()
 
 	if err := g.Generate(it, funcs); err != nil {
-		fmt.Println("debug")
 		return err
 	}
 

--- a/sample/other_component.go
+++ b/sample/other_component.go
@@ -11,7 +11,7 @@ type otherComponent struct {
 func NewOtherComponent(s SampleComponent) (OtherComponent, error) {
 	return &otherComponent{
 		s: s,
-	}, ni
+	}, nil
 }
 
 func (s *otherComponent) Exec() error {


### PR DESCRIPTION
## Overview
In current implementation, result of compile failed.
<img width="916" alt="2017-12-12 23 41 20" src="https://user-images.githubusercontent.com/7579796/33890581-0724e908-df97-11e7-8bdd-55fd179f2600.png">

fix generated code to compile success code.

```sh
[midori@midori:~/src/golang/src/github.com/akito0107/dicon on fix-generate-code]
% make main
go build -ldflags "-X 'main.version=0.0.1' -X 'main.revision='" -o bin/dicon main.go
[midori@midori:~/src/golang/src/github.com/akito0107/dicon on fix-generate-code]
% ./bin/dicon generate --pkg sample
[midori@midori:~/src/golang/src/github.com/akito0107/dicon on fix-generate-code]
% cd sample
[midori@midori:~/src/golang/src/github.com/akito0107/dicon/sample on fix-generate-code]
% go build
# github.com/akito0107/dicon/sample
./dicon_gen.go:17:8: cannot use dicontainer literal (type *dicontainer) as type DIContainer in return argument:
        *dicontainer does not implement DIContainer (missing Sample2Component method)
```
(remain one more compiled error..)

### Supplement
I first tried to pull request for OSS.  
If I made bug, Sorry.
