### PR TITLE
feat: print correct version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 NAME := dicon
 VERSION := 0.0.1
-REVISON := $(shell git rev-parse --short HEAD)
+REVISION := $(shell git rev-parse --short HEAD)
 LDFLAGS := -X 'main.version=$(VERSION)' -X 'main.revision=$(REVISION)'
 PACKAGENAME := github.com/akito0107/dicon
 

--- a/main.go
+++ b/main.go
@@ -13,9 +13,20 @@ import (
 	"github.com/urfave/cli"
 )
 
+var (
+	version  = "master"
+	revision string
+)
+
 func main() {
+	cli.VersionPrinter = func(c *cli.Context) {
+		fmt.Printf("%s version=%s revision=%s\n", c.App.Name, c.App.Version, revision)
+	}
+
 	app := cli.NewApp()
+
 	app.Name = "dicon"
+	app.Version = version
 	app.Usage = "DICONtainer Generator"
 
 	app.Commands = []cli.Command{


### PR DESCRIPTION
current:
```bash
$ dicon -v
dicon version 0.0.0
```
expected:
```bash
$ dicon -v
dicon version 0.0.1
```